### PR TITLE
User and Role Stores Should be Scoped

### DIFF
--- a/PTrampert.AspNetCore.Identity.MongoDB/IdentityUser.cs
+++ b/PTrampert.AspNetCore.Identity.MongoDB/IdentityUser.cs
@@ -31,45 +31,33 @@ namespace PTrampert.AspNetCore.Identity.MongoDB
 
         public IEnumerable<AuthToken> AuthTokens
         {
-            get { return authTokens ?? new List<AuthToken>(); }
-            private set { authTokens = value.ToList(); }
+            get => authTokens ?? new List<AuthToken>();
+            private set => authTokens = value.ToList();
         }
 
         private List<PersistedUserLoginInfo> logins;
         [BsonIgnoreIfNull]
         public IEnumerable<PersistedUserLoginInfo> Logins
         {
-            get
-            {
-                return logins ?? new List<PersistedUserLoginInfo>();
-            }
+            get => logins ?? new List<PersistedUserLoginInfo>();
 
-            private set
-            {
-                logins = value.ToList();
-            }
+            private set => logins = value.ToList();
         }
 
         private List<PersistedClaim> claims;
         [BsonIgnoreIfNull]
         public IEnumerable<PersistedClaim> Claims
         {
-            get
-            {
-                return claims ?? new List<PersistedClaim>();
-            }
-            private set
-            {
-                claims = value.ToList();
-            }
+            get => claims ?? new List<PersistedClaim>();
+            private set => claims = value.ToList();
         }
 
         private List<string> roles;
         [BsonIgnoreIfNull]
         public IEnumerable<string> Roles
         {
-            get { return roles ?? new List<string>(); }
-            private set { roles = value.ToList(); }
+            get => roles ?? new List<string>();
+            private set => roles = value.ToList();
         }
 
         public IdentityUser()

--- a/PTrampert.AspNetCore.Identity.MongoDB/ServiceCollectionExtensions.cs
+++ b/PTrampert.AspNetCore.Identity.MongoDB/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ namespace PTrampert.AspNetCore.Identity.MongoDB
         public static IServiceCollection AddMongoUserStore<T>(this IServiceCollection services, Action<MongoUserStoreOptions<T>> configure) where T : IdentityUser
         {
             services.Configure(configure);
-            services.AddSingleton<IUserStore<T>, MongoUserStore<T>>();
+            services.AddScoped<IUserStore<T>, MongoUserStore<T>>();
             return services;
         }
 
@@ -65,7 +65,7 @@ namespace PTrampert.AspNetCore.Identity.MongoDB
         public static IServiceCollection AddMongoUserStore<T>(this IServiceCollection services, IConfiguration configuration) where T: IdentityUser
         {
             services.Configure<MongoUserStoreOptions<T>>(configuration);
-            services.AddSingleton<IUserStore<T>, MongoUserStore<T>>();
+            services.AddScoped<IUserStore<T>, MongoUserStore<T>>();
             return services;
         }
 
@@ -90,7 +90,7 @@ namespace PTrampert.AspNetCore.Identity.MongoDB
             Action<MongoRoleStoreOptions> configure)
         {
             services.Configure(configure);
-            services.AddSingleton<IRoleStore<IdentityRole>, MongoRoleStore>();
+            services.AddScoped<IRoleStore<IdentityRole>, MongoRoleStore>();
             return services;
         }
 
@@ -123,7 +123,7 @@ namespace PTrampert.AspNetCore.Identity.MongoDB
             IConfiguration configuration)
         {
             services.Configure<MongoRoleStoreOptions>(configuration);
-            services.AddSingleton<IRoleStore<IdentityRole>, MongoRoleStore>();
+            services.AddScoped<IRoleStore<IdentityRole>, MongoRoleStore>();
             return services;
         }
     }


### PR DESCRIPTION
User and role stores should be scoped, as that's what's expected by ASP.NET Core Identity.